### PR TITLE
Make `--pedantic` flag optional

### DIFF
--- a/src/commands/build.yml
+++ b/src/commands/build.yml
@@ -9,7 +9,7 @@ parameters:
   stack-arguments:
     description: "Additional arguments for ALL Stack invocations"
     type: string
-    default: ""
+    default: "--pedantic"
   weeder:
     description: "Run Weeder?"
     type: boolean
@@ -31,7 +31,6 @@ steps:
         --stack-yaml "<<parameters.stack-yaml>>"
         --no-terminal
         <<parameters.stack-arguments>>
-        --pedantic
         --test
         --no-run-tests
   - save_cache:


### PR DESCRIPTION
While the `—pedantic` flag is useful for keeping a project clean, it may be inconvenient for existing projects with a large number of warnings. Making this flag optional may help address these warnings incrementally.